### PR TITLE
codeowners: match (owned path)

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7,3 +7,4 @@ function init() {
 }
 
 module.exports = { init, APP_NAME, APP_VERSION };
+// codeowners match EE0D5777-1374-4F0F-8E22-CEE207AEA8D9


### PR DESCRIPTION
Touches frontend/app.js (owned by @sileht-test in CODEOWNERS). The 'Code owner review satisfied' protection should stay RED until @sileht-test approves.