### PR TITLE
codeowners: no-match (unowned path)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -17,3 +17,4 @@ Set your environment variables:
 - `APP_ENV`: development or production
 - `APP_PORT`: port number (default: 3000)
 - `APP_DEBUG`: enable debug mode (default: false)
+<!-- codeowners no-match 377F583F-446C-4712-A5CA-D1ECADC277CD -->


### PR DESCRIPTION
Touches only docs/guide.md (no owner in CODEOWNERS). The 'Code owner review satisfied' protection should be GREEN with no code owner review required.