### PR TITLE
codeowners: match (owned path)

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7,3 +7,4 @@ function init() {
 }
 
 module.exports = { init, APP_NAME, APP_VERSION };
+// codeowners match C359280E-1797-442A-8A8B-9D78DBE74287


### PR DESCRIPTION
Touches frontend/app.js (owned by @sileht-test in CODEOWNERS). The 'Code owner review satisfied' protection should stay RED until @sileht-test approves.