### PR TITLE
fix: add required 'if' to code owner merge protection

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -52,5 +52,7 @@ merge_protections:
       Tests Mergify's CODEOWNERS support. A PR touching an owned path
       (see .github/CODEOWNERS) stays red until an owner approves it.
       A PR touching only unowned paths passes vacuously.
+    if:
+      - base = main
     success_conditions:
       - github-code-owner-review-satisfied


### PR DESCRIPTION
The merge_protections rule was missing the required `if` property, making the whole Mergify config invalid. Adds `if: base = main`.