### PR TITLE
codeowners: no-match (unowned path)

### DIFF
--- a/create-pr-two-commits.sh
+++ b/create-pr-two-commits.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Create a PR with two commits.
+set -euo pipefail
+
+BRANCH="${1:-test/two-commits-$(date +%s)}"
+BASE="$(git rev-parse --abbrev-ref HEAD)"
+
+git switch -c "$BRANCH"
+
+# First commit
+echo "change 1 - $(date)" >> two-commits.txt
+git add two-commits.txt
+git commit -m "test: first commit"
+
+# Second commit
+echo "change 2 - $(date)" >> two-commits.txt
+git add two-commits.txt
+git commit -m "test: second commit"
+
+git push -u origin "$BRANCH"
+
+gh pr create \
+  --base "$BASE" \
+  --head "$BRANCH" \
+  --title "test: PR with two commits" \
+  --body "Test PR containing two commits."
+
+git main

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -18,3 +18,4 @@ Set your environment variables:
 - `APP_PORT`: port number (default: 3000)
 - `APP_DEBUG`: enable debug mode (default: false)
 <!-- codeowners no-match DBC8A686-63FF-440C-85DE-A72AD40B710D -->
+<!-- codeowners no-match 33CF43B9-8A2A-4572-BD5B-6A08ADB41EE4 -->


### PR DESCRIPTION
Touches only docs/guide.md (no owner in CODEOWNERS). The 'Code owner review satisfied' protection should be GREEN with no code owner review required.