### PR TITLE
codeowners: no-match (unowned path)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -18,3 +18,4 @@ Set your environment variables:
 - `APP_PORT`: port number (default: 3000)
 - `APP_DEBUG`: enable debug mode (default: false)
 <!-- codeowners no-match DBC8A686-63FF-440C-85DE-A72AD40B710D -->
+<!-- codeowners no-match D2ABA1D3-D4D9-4F5F-AEE9-59E2DF625F6A -->


### PR DESCRIPTION
Touches only docs/guide.md (no owner in CODEOWNERS). The 'Code owner review satisfied' protection should be GREEN with no code owner review required.