### PR TITLE
codeowners: match (owned path)

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7,3 +7,4 @@ function init() {
 }
 
 module.exports = { init, APP_NAME, APP_VERSION };
+// codeowners match 309C3E5A-2D32-42E2-BBC3-4D74988E012C


### PR DESCRIPTION
Touches frontend/app.js (owned by @sileht-test in CODEOWNERS). The 'Code owner review satisfied' protection should stay RED until @sileht-test approves.